### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/arch/x86/kvm/emulate.c
+++ b/arch/x86/kvm/emulate.c
@@ -1736,19 +1736,34 @@ static int load_segment_descriptor(struct x86_emulate_ctxt *ctxt,
 {
 	u8 cpl = ctxt->ops->cpl(ctxt);
 
+
+	/*
 	/*
 	 * None of MOV, POP and LSS can load a NULL selector in CPL=3, but
+	 * None of MOV, POP and LSS can load a NULL selector in CPL=3, but
+	 * they can load it at CPL<3 (Intel's manual says only LSS can,
 	 * they can load it at CPL<3 (Intel's manual says only LSS can,
 	 * but it's wrong).
+	 * but it's wrong).
+	 *
 	 *
 	 * However, the Intel manual says that putting IST=1/DPL=3 in
+	 * However, the Intel manual says that putting IST=1/DPL=3 in
+	 * an interrupt gate will result in SS=3 (the AMD manual instead
 	 * an interrupt gate will result in SS=3 (the AMD manual instead
 	 * says it doesn't), so allow SS=3 in __load_segment_descriptor
+	 * says it doesn't), so allow SS=3 in __load_segment_descriptor
+	 * and only forbid it here.
 	 * and only forbid it here.
 	 */
+	 */
+	if (seg == VCPU_SREG_SS && selector == 3 &&
 	if (seg == VCPU_SREG_SS && selector == 3 &&
 	    ctxt->mode == X86EMUL_MODE_PROT64)
+	    ctxt->mode == X86EMUL_MODE_PROT64)
 		return emulate_exception(ctxt, GP_VECTOR, 0, true);
+		return emulate_exception(ctxt, GP_VECTOR, 0, true);
+
 
 	return __load_segment_descriptor(ctxt, selector, seg, cpl,
 					 X86_TRANSFER_NONE, NULL);


### PR DESCRIPTION
## Summary
This PR fixes a potential security vulnerability in cloned code that appears to have missed an upstream security patch.

## Details
- **Affected file**: `arch/x86/kvm/emulate.c`
- **Upstream fix commit**: https://github.com/torvalds/linux/commit/33ab91103b3415e12457e3104f0e4517ce12d0f3
- **Clone similarity score**: 0.996780

## What this PR does
- Applies the upstream security fix logic to the cloned implementation in this repository.

## References
- Upstream patch commit: https://github.com/torvalds/linux/commit/33ab91103b3415e12457e3104f0e4517ce12d0f3
