### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/drivers/net/wireless/ath/ath9k/htc_hst.c
+++ b/drivers/net/wireless/ath/ath9k/htc_hst.c
@@ -180,6 +180,7 @@ static int htc_config_pipe_credits(struct htc_target *target)
 	time_left = wait_for_completion_timeout(&target->cmd_wait, HZ);
 	if (!time_left) {
 		dev_err(target->dev, "HTC credit config timeout\n");
+		kfree_skb(skb);
 		return -ETIMEDOUT;
 	}
 
@@ -215,6 +216,7 @@ static int htc_setup_complete(struct htc_target *target)
 	time_left = wait_for_completion_timeout(&target->cmd_wait, HZ);
 	if (!time_left) {
 		dev_err(target->dev, "HTC start timeout\n");
+		kfree_skb(skb);
 		return -ETIMEDOUT;
 	}
 
@@ -291,6 +293,7 @@ int htc_connect_service(struct htc_target *target,
 	if (!time_left) {
 		dev_err(target->dev, "Service connection timeout for: %d\n",
 			service_connreq->service_id);
+		kfree_skb(skb);
 		return -ETIMEDOUT;
 	}
 


### PR DESCRIPTION
This PR fixes a potential security vulnerability in drivers/net/wireless/ath/ath9k/htc_hst.c that was cloned from https://github.com/torvalds/linux but did not receive the security patch.

Details:
Affected Function: drivers/net/wireless/ath/ath9k/htc_hst.c
Original Fix: https://github.com/torvalds/linux/commit/853acf7caf10b828102d92d05b5c101666a6142b

What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

References:
https://github.com/torvalds/linux/commit/853acf7caf10b828102d92d05b5c101666a6142b
https://nvd.nist.gov/vuln/detail/cve-2019-19073
Please review and merge this PR to ensure your repository is protected against this potential vulnerability.